### PR TITLE
Fix container has runAsNonRoot and image has non-numeric user (nginx), cannot verify user is non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,5 +39,6 @@ RUN sed -i.orig -e '/user[[:space:]]\+nginx/d' -e 's@pid[[:space:]]\+.*@pid /tmp
     diff -u /etc/nginx/nginx.conf.orig /etc/nginx/nginx.conf ||: && \
     chown nginx /usr/share/nginx/html/index.html && \
     chown -Rc nginx /var/cache/nginx
-USER nginx
+# Equivalent to 'USER nginx', see: https://github.com/InseeFrLab/onyxia-web/pull/279
+USER 101
 ENTRYPOINT sh -c "npx embed-environnement-variables && nginx -g 'daemon off;'"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://datalab.sspcloud.fr",
     "name": "onyxia-web",
-    "version": "0.31.0",
+    "version": "0.32.0",
     "license": "MIT",
     "devDependencies": {
         "@storybook/addon-actions": "^6.1.11",


### PR DESCRIPTION
I'm using a gatekeeper mutation, to force `runAsNonRoot` to `false` (similar to [here](https://github.com/open-policy-agent/gatekeeper-library/blob/master/library/experimental/mutation/pod-security-policy/users/samples/mutation-mustRunAsNonRoot.yaml)).

Unfortunately the PSP admission [don't know the uid when it's a string](https://stackoverflow.com/questions/49720308/kubernetes-podsecuritypolicy-set-to-runasnonroot-container-has-runasnonroot-and), the Pod fails with:

```
Error: container has runAsNonRoot and image has non-numeric user (nginx), cannot verify user is non-root
(pod: "onyxia-ui-78d96499c7-vh5nd_onyxia(4ee7c357-9d03-4069-a8ad-31908855abd1)", container: onyxia)
```